### PR TITLE
Fix failing Windows test

### DIFF
--- a/pdslogger/__init__.py
+++ b/pdslogger/__init__.py
@@ -2454,7 +2454,8 @@ def file_handler(logpath, level=HIDDEN+1, rotation='none', suffix=''):
                     match = regex.match(filepath.name)
                     if match:
                         max_version = max(int(match.group(1)), max_version)
-            except NotImplementedError:
+            except NotImplementedError:  # pragma: no cover
+                # There are currently no remote file systems that don't support glob
                 scheme = str(logpath).partition('://')[0]
                 raise ValueError('numbered rotation is not supported for remote scheme '
                                  f'"{scheme}:"')

--- a/tests/test_pdslogger.py
+++ b/tests/test_pdslogger.py
@@ -1850,6 +1850,7 @@ class Test_PdsLogger(unittest.TestCase):
             self.assertTrue(recs[-3].endswith('This is a warning'))
             self.assertTrue(recs[-2].endswith('This is an error'))
 
+            handler.close()
             with warnings.catch_warnings():  # ignore the known warning about AAREADME.TXT
                 warnings.filterwarnings('ignore', message=r'.*cannot be uploaded')
                 pl.remove_all_handlers()


### PR DESCRIPTION
Fixes #18.

This was caused due to a file handler staying open while a log file was being rotated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved resource cleanup in a file-handling test to close handlers before warning checks.
* **Style / Chores**
  * Added a coverage annotation and explanatory comment to an exception-handling branch to clarify intent (no behavior change).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->